### PR TITLE
chore: update LiteLLM container image references in Terraform configu…

### DIFF
--- a/docs/Terraform_Blueprint.md
+++ b/docs/Terraform_Blueprint.md
@@ -75,7 +75,7 @@ variable "tags" {
 variable "container_image" {
   type        = string
   description = "LiteLLM container image"
-  default     = "ghcr.io/berriai/litellm:latest"
+  default     = "litellm/litellm:v1.81.15@sha256:d104dae60f1a0c8fc93f837ec30ec4e6430ee70b0d3636874c26bc9920ae34a7"
 }
 
 variable "container_port" {

--- a/infra/env/dev/variables.tf
+++ b/infra/env/dev/variables.tf
@@ -36,8 +36,8 @@ variable "gateway_key" {
 
 variable "container_image" {
   type        = string
-  description = "LiteLLM container image"
-  default     = "ghcr.io/berriai/litellm:latest"
+  description = "LiteLLM container image (use amd64 digest for Azure Container Apps)"
+  default     = "litellm/litellm:v1.81.15@sha256:d104dae60f1a0c8fc93f837ec30ec4e6430ee70b0d3636874c26bc9920ae34a7"
 }
 
 variable "codex_model" { type = string }

--- a/infra/env/prod/variables.tf
+++ b/infra/env/prod/variables.tf
@@ -36,8 +36,8 @@ variable "gateway_key" {
 
 variable "container_image" {
   type        = string
-  description = "LiteLLM container image"
-  default     = "ghcr.io/berriai/litellm:latest"
+  description = "LiteLLM container image (use amd64 digest for Azure Container Apps)"
+  default     = "litellm/litellm:v1.81.15@sha256:d104dae60f1a0c8fc93f837ec30ec4e6430ee70b0d3636874c26bc9920ae34a7"
 }
 
 variable "codex_model" { type = string }

--- a/infra/env/uat/variables.tf
+++ b/infra/env/uat/variables.tf
@@ -36,8 +36,8 @@ variable "gateway_key" {
 
 variable "container_image" {
   type        = string
-  description = "LiteLLM container image"
-  default     = "ghcr.io/berriai/litellm:latest"
+  description = "LiteLLM container image (use amd64 digest for Azure Container Apps)"
+  default     = "litellm/litellm:v1.81.15@sha256:d104dae60f1a0c8fc93f837ec30ec4e6430ee70b0d3636874c26bc9920ae34a7"
 }
 
 variable "codex_model" { type = string }

--- a/infra/modules/aigateway_aca/variables.tf
+++ b/infra/modules/aigateway_aca/variables.tf
@@ -37,7 +37,7 @@ variable "tags" {
 # LiteLLM container
 variable "container_image" {
   type        = string
-  description = "LiteLLM container image (e.g. ghcr.io/berriai/litellm:v1.34.0)"
+  description = "LiteLLM container image; use amd64 digest for Azure Container Apps (e.g. litellm/litellm:v1.81.15@sha256:...)"
 
 }
 


### PR DESCRIPTION
…rations

- Changed the default value of the `container_image` variable across multiple environment-specific Terraform files to use the new image digest for LiteLLM, ensuring consistency and reliability in deployments.
- Updated the description of the `container_image` variable to clarify the use of the amd64 digest for Azure Container Apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default LiteLLM container image used across all deployment environments (development, production, and staging) from a floating latest tag to a specific pinned version (v1.81.15) with SHA256 digest verification.

* **Documentation**
  * Updated configuration documentation to include specific amd64 digest requirements and operational guidance for Azure Container Apps deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->