### PR TITLE
fix: update embeddings_api_version to 2024-02-01 for dev and uat

### DIFF
--- a/infra/env/dev/terraform.tfvars
+++ b/infra/env/dev/terraform.tfvars
@@ -11,7 +11,7 @@ codex_model       = "gpt-5.3-codex"
 codex_api_version = "2025-04-01-preview"
 
 embedding_deployment   = "text-embedding-3-large"
-embeddings_api_version = "2023-05-15"
+embeddings_api_version = "2024-02-01"
 
 # Rotate before expiration; extend or run rotation job per ops runbook
 secrets_expiration_date = "2027-03-31T00:00:00Z"

--- a/infra/env/uat/terraform.tfvars
+++ b/infra/env/uat/terraform.tfvars
@@ -14,7 +14,7 @@ codex_model       = "gpt-5.3-codex"
 codex_api_version = "2025-04-01-preview"
 
 embedding_deployment   = "text-embedding-3-large"
-embeddings_api_version = "2023-05-15"
+embeddings_api_version = "2024-02-01"
 
 # Rotate before expiration; CI workflow or alert must notify owners. See secrets_expiration_date in runbook.
 secrets_expiration_date = "2027-03-31T00:00:00Z"


### PR DESCRIPTION
text-embedding-3-large requires API version >= 2024-02-01. Dev and UAT had the outdated 2023-05-15 (prod was already correct).

https://claude.ai/code/session_01NBA8iwQwfRZhNVEvFkMeVc

# Pull Request Checklist

## Summary

- What changed?
- Why was it needed?

## Validation

- [ ] Local checks run (if applicable)
- [ ] Relevant workflow/jobs observed

## Deployment Notes

- [ ] No environment/config changes required
- [ ] Environment/config changes required (describe below)

## UAT Toggle (PRs to `main`)

- Add label `run-uat` to this PR to enable UAT deployment (`deploy-uat`).
- Remove label `run-uat` to skip UAT deployment.

## Risk / Rollback

- Risk level: low / medium / high
- Rollback plan:
